### PR TITLE
Fix grayscale image extraction

### DIFF
--- a/extract_dataset.py
+++ b/extract_dataset.py
@@ -39,7 +39,13 @@ def convert(X, Y, category):
     global class_count, total_images, zf, last_printed, converted_images
 
     for ix in range(0, len(X)):
-        raw_img_data = (np.reshape(X[ix], (image_width, image_height, image_channels)) * 255).astype(np.uint8)
+        img_shape = ()
+        if image_channels == 1:
+            img_shape = (image_width, image_height)
+        else:
+            img_shape = (image_width, image_height, image_channels)
+
+        raw_img_data = (np.reshape(X[ix], img_shape) * 255).astype(np.uint8)
         labels = Y[ix]['boundingBoxes']
 
         images_dir = os.path.join(out_dir, category, 'images')


### PR DESCRIPTION
When using a grayscale training dataset `extract_dataset.py` fails with the following error:

``` sh
 Traceback (most recent call last):
   File "/usr/local/lib/python3.8/dist-packages/PIL/Image.py", line 2813, in fromarray
     mode, rawmode = _fromarray_typemap[typekey]
 KeyError: ((1, 1, 1), '|u1')

 The above exception was the direct cause of the following exception:

 Traceback (most recent call last):
   File "extract_dataset.py", line 79, in <module>
     convert(X=X_train, Y=Y_train, category='train')
   File "extract_dataset.py", line 50, in convert
     im = Image.fromarray(raw_img_data)
   File "/usr/local/lib/python3.8/dist-packages/PIL/Image.py", line 2815, in fr
 omarray
     raise TypeError("Cannot handle this data type: %s, %s" % typekey) from e
 TypeError: Cannot handle this data type: (1, 1, 1), |u1
```

This PR fixes this issue